### PR TITLE
Code / comment cleanup and JSHint fixes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,6 @@ module.exports = function (glob, options, callback) {
 	// are detected
 	watchStream.pipe(through.obj(watchImportStream));
 
-	// In order for the pipe to receive updates that the main less file changed
-	// we must pipe the stream to itself.
-	return watchStream.pipe(watchStream);
+	// Return the stream;
+	return watchStream;
 };

--- a/index.js
+++ b/index.js
@@ -126,5 +126,9 @@ module.exports = function (glob, options, callback) {
 	// Pipe the watch stream into the imports watcher so whenever any of the
 	// files change, we re-generate our @import watcher so removals/additions
 	// are detected
-	return watchStream.pipe(through.obj(watchImportStream));
+	watchStream.pipe(through.obj(watchImportStream));
+
+	// In order for the pipe to receive updates that the main less file changed
+	// we must pipe the stream to itself.
+	return watchStream.pipe(watchStream);
 };

--- a/index.js
+++ b/index.js
@@ -2,16 +2,13 @@
 
 var PLUGIN_NAME = 'gulp-watch-less';
 
-var gulp = require('gulp'),
-	gutil = require('gulp-util'),
+var gutil = require('gulp-util'),
 	watch = require('gulp-watch'),
 	mergeDefaults = require('lodash.defaults'),
 	through = require('through2'),
 	less = require('less');
 
 function getLessFileImports(vinylFile, options, cb) {
-	var imports = [];
-
 	// Support (file, cb) signature.
 	if(typeof options === 'function') {
 		cb = options;
@@ -35,12 +32,10 @@ function getLessFileImports(vinylFile, options, cb) {
 			}
 
 			// Generate imports list from the files hash (sorted).
-			var imports = Object.keys(imports.files).sort();
-
-			cb(err, imports);
+			cb(err, Object.keys(imports.files).sort());
 		}
 	);
-};
+}
 
 // Tracks watch streams e.g. `{filepath}: stream`.
 var _streams = Object.create(null);
@@ -95,7 +90,7 @@ module.exports = function (glob, options, callback) {
 		less: {}
 	});
 
-	var watchStream = watch(glob, options, callback)
+	var watchStream = watch(glob, options, callback);
 
 	function watchImportStream(file, enc, cb) {
 		var filePath = file.path;
@@ -113,7 +108,9 @@ module.exports = function (glob, options, callback) {
 	}
 
 	// Close all import watch streams when the watchStream ends.
-	watchStream.on('end', function() { Object.keys(_streams).forEach(closeStream); });
+	// TODO `closeStream` is undefined. This should be defined to prevent runtime
+	// errors and so that streams are properly closed.
+	// watchStream.on('end', function() { Object.keys(_streams).forEach(closeStream); });
 
 	// Pipe the watch stream into the imports watcher so whenever any of the files
 	// change, we re-generate our @import watcher so removals/additions are

--- a/index.js
+++ b/index.js
@@ -21,15 +21,15 @@ function getLessFileImports(file, options, cb) {
 	// Parse the filepath, using file path as `filename` option
 	less.parse(file.contents.toString('utf8'), mergeDefaults({
 		filename: file.path
-	}, 
-	options || {}), 
+	},
+	options || {}),
 	function(err, root, imports, options) {
 		// Add a better error message / properties
-		if (err) { 
+		if (err) {
 			err.lineNumber = err.line;
 			err.fileName = err.filename;
 			err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
-		} 
+		}
 
 		// Generate imports list from the files hash (sorted)
 		var imports = Object.keys(imports.files).sort();
@@ -39,11 +39,11 @@ function getLessFileImports(file, options, cb) {
 };
 
 // Tracks watch streams e.g. `{filepath}: stream`
-var _streams = Object.create(null); 
+var _streams = Object.create(null);
 
 // Name of the event fired when @imports cause file to change
 // (Overwrites the current file.event set by gulp-watch/gaze)
-var changeEvent = 'changed:by:import'; 
+var changeEvent = 'changed:by:import';
 
 // Import generator
 function watchLessImports(file, options, cb, done) {
@@ -75,7 +75,7 @@ function watchLessImports(file, options, cb, done) {
 
 		// If we found some imports...
 		if(imports.length) {
-			// Generate new watch stream 
+			// Generate new watch stream
 			watchStream = _streams[filePath] = watch(imports, options, cb);
 
 			// Expose @import list on the stream
@@ -104,7 +104,7 @@ module.exports = function (glob, options, callback) {
 		var filePath = file.path;
 
 		// Passthrough the file
-		this.push(file); 
+		this.push(file);
 
 		// Make sure we only execute the logic on external events
 		// and not when our own internal changeEvent triggers it
@@ -123,12 +123,8 @@ module.exports = function (glob, options, callback) {
 	// Close all import watch streams when the watchStream ends
 	watchStream.on('end', function() { Object.keys(_streams).forEach(closeStream); });
 
-	// Immediately apply the globs and watch all imports, since otherwise we'd
-	// have to edit the files once before any @import watching would activate
-	gulp.src(glob).pipe(through.obj(watchImportStream));
-
 	// Pipe the watch stream into the imports watcher so whenever any of the
-	// files change, we re-generate our @import watcher so removals/additions 
+	// files change, we re-generate our @import watcher so removals/additions
 	// are detected
 	return watchStream.pipe(through.obj(watchImportStream));
 };

--- a/index.js
+++ b/index.js
@@ -9,76 +9,76 @@ var gulp = require('gulp'),
 	through = require('through2'),
 	less = require('less');
 
-// Generates list of @import paths for a given Vinyl file
-function getLessFileImports(file, options, cb) {
+function getLessFileImports(vinylFile, options, cb) {
 	var imports = [];
 
-	// Support (file, cb) signature
+	// Support (file, cb) signature.
 	if(typeof options === 'function') {
-		cb = options; options = null;
+		cb = options;
+		options = null;
 	}
 
-	// Parse the filepath, using file path as `filename` option
-	less.parse(file.contents.toString('utf8'), mergeDefaults({
-		filename: file.path
-	},
-	options || {}),
-	function(err, root, imports, options) {
-		// Add a better error message / properties
-		if (err) {
-			err.lineNumber = err.line;
-			err.fileName = err.filename;
-			err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
+	less.parse(
+		vinylFile.contents.toString('utf8'),
+		mergeDefaults(
+			{
+				filename: vinylFile.path
+			},
+			options || {}
+		),
+		function(err, root, imports, options) {
+			// Add a better error message / properties.
+			if (err) {
+				err.lineNumber = err.line;
+				err.fileName = err.filename;
+				err.message = err.message + ' in file ' + err.fileName + ' line no. ' + err.lineNumber;
+			}
+
+			// Generate imports list from the files hash (sorted).
+			var imports = Object.keys(imports.files).sort();
+
+			cb(err, imports);
 		}
-
-		// Generate imports list from the files hash (sorted)
-		var imports = Object.keys(imports.files).sort();
-
-		cb(err, imports);
-	});
+	);
 };
 
-// Tracks watch streams e.g. `{filepath}: stream`
+// Tracks watch streams e.g. `{filepath}: stream`.
 var _streams = Object.create(null);
 
-// Name of the event fired when @imports cause file to change
-// (Overwrites the current file.event set by gulp-watch/gaze)
+// Name of the event fired when @imports cause file to change. Overwrites the
+// current file.event set by gulp-watch/gaze.
 var changeEvent = 'changed:by:import';
 
-// Import generator
 function watchLessImports(file, options, cb, done) {
 	var filePath = file.path,
 		watchStream = _streams[filePath];
 
-	// Generate an @import list via LESS...
 	getLessFileImports(file, options.less, function(err, imports) {
 		var oldImports;
 
-		// Emit the error if one was returned
 		if (err) { cb(new gutil.PluginError(PLUGIN_NAME, err)); }
 
-		// If a previous watch stream is active...
 		if(watchStream) {
 			oldImports = watchStream._imports;
 
 			// Check to ensure the @import arrays are identical.
 			if(oldImports.length && oldImports.join() === imports.join()) {
-				done(); return; // Don't do anything further!
+				done();
+				return;
 			}
 
-			// Clean up previous watch stream
+			// Clean up previous watch stream.
 			watchStream.end();
 			watchStream.unpipe();
 			watchStream.close();
 			delete _streams[filePath];
 		}
 
-		// If we found some imports...
 		if(imports.length) {
-			// Generate new watch stream
+			// Generate new watch stream.
 			watchStream = _streams[filePath] = watch(imports, options, cb);
 
-			// Expose @import list on the stream
+			// Expose @import list on the stream.
 			watchStream._imports = imports;
 		}
 
@@ -87,45 +87,37 @@ function watchLessImports(file, options, cb, done) {
 }
 
 module.exports = function (glob, options, callback) {
-	// No-op callback if not given
 	if(!options) { options = {}; }
 	if(!callback) { callback = function() {}; }
 
-	// Merge defaults
 	options = mergeDefaults(options, {
-		name: 'LESS', // Use LESS name by default
-		less: {} // No LESS options by default
+		name: 'LESS',
+		less: {}
 	});
 
-	// Generate a basic `gulp-watch` stream
 	var watchStream = watch(glob, options, callback)
 
 	function watchImportStream(file, enc, cb) {
 		var filePath = file.path;
 
-		// Passthrough the file
 		this.push(file);
 
-		// Make sure we only execute the logic on external events
-		// and not when our own internal changeEvent triggers it
+		// Make sure we only execute the logic on external events and not when our
+		// own internal changeEvent triggers it.
 		if(file.event !== changeEvent) {
 			watchLessImports(file, options, function(importFile) {
 				watchStream._gaze.emit('all', changeEvent, filePath);
 			},
 			cb);
-		}
-
-		// Otherwise exeute the callback logic immediately
-		else { cb(); }
-
+		} else { cb(); }
 	}
 
-	// Close all import watch streams when the watchStream ends
+	// Close all import watch streams when the watchStream ends.
 	watchStream.on('end', function() { Object.keys(_streams).forEach(closeStream); });
 
-	// Pipe the watch stream into the imports watcher so whenever any of the
-	// files change, we re-generate our @import watcher so removals/additions
-	// are detected
+	// Pipe the watch stream into the imports watcher so whenever any of the files
+	// change, we re-generate our @import watcher so removals/additions are
+	// detected.
 	watchStream.pipe(through.obj(watchImportStream));
 
 	// In order for the pipe to receive updates that the main less file changed


### PR DESCRIPTION
I found quite a few instances where the code does just as good, or better a job at describing what it does than its corresponding comment. In many instances the comment is just noise. In some cases, variables were renamed to give them better meaning rather than relying on a comment to do the same thing.

JSHint violations were also fixed as part of this PR.

I also added a `TODO` to fix an issue where a callback isn't actually defined and commented out the call. If the code actually went down that path then there'd be a runtime error. Referenced in #4.

Happy to discuss these changes since changes like these can be somewhat subjective.

This also includes commits from #3. 
